### PR TITLE
io circular depends

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,4 @@ test
 build.js
 dist/image-io/
 dist/mesh-io/
+examples/

--- a/doc/content/docs/itk_js_to_itk_wasm_migration_guide.md
+++ b/doc/content/docs/itk_js_to_itk_wasm_migration_guide.md
@@ -26,15 +26,8 @@ to:
 
 
 ```js
-import { IntTypes } from 'itk'
+import { IntTypes } from 'itk-wasm'
 ```
-
-Or, to help bundlers with limited tree shaking,
-
-```js
-import { IntTypes } from 'itk/browser/index.js'
-```
-
 
 Node module import migration:
 
@@ -47,7 +40,7 @@ const IntTypes = require('itk/IntTypes.js')
 to:
 
 ```js
-import { IntTypes } from 'itk'
+import { IntTypes } from 'itk-wasm'
 ```
 
 ## TypeScript support

--- a/examples/Webpack/src/index.js
+++ b/examples/Webpack/src/index.js
@@ -1,4 +1,4 @@
-import { readFile } from 'itk-wasm/dist/browser/index.js'
+import { readFile } from 'itk-wasm'
 import curry from 'curry'
 
 const outputFileInformation = curry(function outputFileInformation (outputTextArea, event) {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,18 @@
   "version": "1.0.0-a.14",
   "description": "High-performance spatial analysis in a web browser, Node.js, and reproducible execution across programming languages and hardware architectures.",
   "main": "./dist/index.js",
+  "browser": {
+    "./index.js": "./dist/browser/index.js"
+  },
+  "exports": {
+    ".": {
+      "browser": "./dist/browser/index.js",
+      "import": "./dist/node/index.js",
+      "umd": "./dist/umd/itk-wasm.js",
+      "package.json": "./package.json",
+      "./index.d.ts": "./dist/index.d.ts"
+    }
+  },
   "type": "module",
   "types": "./dist/index.d.ts",
   "directories": {

--- a/src/io/internal/bindings/image-io.package.json.in
+++ b/src/io/internal/bindings/image-io.package.json.in
@@ -29,6 +29,5 @@
   "devDependencies": {
   },
   "dependencies": {
-    "itk-wasm": "sem-ver"
   }
 }

--- a/src/io/internal/bindings/mesh-io.package.json.in
+++ b/src/io/internal/bindings/mesh-io.package.json.in
@@ -29,6 +29,5 @@
   "devDependencies": {
   },
   "dependencies": {
-    "itk-wasm": "sem-ver"
   }
 }


### PR DESCRIPTION
- doc(WebPackExample): Update for itk-wasm
- feat(readImageDICOMArrayBufferSeries): Initial addition
- build(VTK): Only build IO
- feat(io-packages): Add main entry to help WebPack
- build(deps-dev): Bump karma from 6.3.6 to 6.3.14
- build(deps): Bump follow-redirects from 1.14.7 to 1.14.8
- refactor(VTK): Remove C++ support
- feat(version): Bump NPM version to 1.0.0-a.13
- feat(IO): Use cbor over zip
- build(CMake): Build and link zstd lib
- feat(Compress): Add CompressStringify
- feat(Compress): Add ParseStringDecompress
- feat(WASMZstdImageIO): Add support for .iwi.cbor.zstd
- feat(readDICOMTagsArrayBuffer): Initial addition
- fix(WorkerPool): Address memory leak in Chrome from reject/resolve
- build(dockcross): Bump to 20220224
- feat(version): Bump NPM version to 1.0.0-a.14
- feat(package.json): Add export maps
- fix: exclude examples folder from npm builds
- build(io-packages): Remove dependency on itk-wasm
